### PR TITLE
scm to https vs none (default ssh)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
 	-->
 	
 	<scm>
-    	<connection>scm:git:https://github.com/zylklab/sinaduraDesktop</connection>
-        <developerConnection>scm:git:https://github.com/zylklab/sinaduraDesktop</developerConnection>
+    	<connection>scm:git:https://github.com/zylklab/sinaduraDesktop.git</connection>
+        <developerConnection>scm:git:https://github.com/zylklab/sinaduraDesktop.git</developerConnection>
         <url>https://github.com/zylklab/sinaduraDesktop</url>
         <tag>develop</tag>
     </scm>
@@ -136,7 +136,7 @@
 			<plugin>
    				<groupId>org.apache.maven.plugins</groupId>
    				<artifactId>maven-release-plugin</artifactId>
-   				<version>2.4</version>
+   				<version>2.5.3</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
 	-->
 	
 	<scm>
-    	<connection>scm:git:https://github.com/zylklab/sinaduraDesktop.git</connection>
-        <developerConnection>scm:git:github.com/zylklab/sinaduraDesktop.git</developerConnection>
+    	<connection>scm:git:https://github.com/zylklab/sinaduraDesktop</connection>
+        <developerConnection>scm:git:https://github.com/zylklab/sinaduraDesktop</developerConnection>
         <url>https://github.com/zylklab/sinaduraDesktop</url>
         <tag>develop</tag>
     </scm>


### PR DESCRIPTION
test to fix jenkins maven release perform error
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.4:prepare (default-cli) on project sinaduraDesktop: Unable to commit files
[ERROR] Provider message:
[ERROR] The git-push command failed.
[ERROR] Command output:
[ERROR] ssh: Could not resolve hostname guszylk: Name or service not known
[ERROR] fatal: Could not read from remote repository.
[ERROR] 
[ERROR] Please make sure you have the correct access rights
[ERROR] and the repository exists.