### PR TITLE
Fixed the dependencies versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>sinadura</groupId>
 	<artifactId>sinaduraDesktop</artifactId>
 	<name>Sinadura Desktop</name>
-	<version>5.0.7</version>
+	<version>5.0.8-SNAPSHOT</version>
 	<description>El origen de sinadura es un software de escritorio para
 		la firma de pdf mediante firma digital. Un aplicativo multiplataforma
 		y una comunidad que ofrece documentación y servicios de valor añadido.
@@ -1597,7 +1597,7 @@
 		<dependency>
 			<groupId>sinadura</groupId>
 			<artifactId>sinaduraCore</artifactId>
-			<version>3.3.21</version>
+			<version>3.3.22-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/config/configuration.properties
+++ b/src/main/resources/config/configuration.properties
@@ -28,7 +28,7 @@
 ## Propiedades generales de sistema. En principio no deberian ser modificadas.
 ##
 # Para comparar con la version del servidor. Tiene que ser numerico!
-application.local.version=502
+application.local.version=508
 application.local.version.string=${project.version}
 idiomas.soportados=es_ES,eu_ES,en_US,ca_ES,pt_BR
 enable.send.button=false


### PR DESCRIPTION
Project version changed to the next snapshot version, which is 5.0.8-SNAPSHOT;
sinaduraCore dependency upgraded to 3.3.22-SNAPSHOT, that now depends on all the newer dependencies with the upgraded bouncy castle version;
Fixed the version of the project to reflect the package version, 508.